### PR TITLE
fix(strings): parse both lang modules

### DIFF
--- a/differ.js
+++ b/differ.js
@@ -102,7 +102,7 @@ function diff(strings) {
   const updatedStrings = [];
   const addedStrings = [];
   for (const i of Object.keys(strings[0])) {
-    if (strings[1][i]) {
+    if (strings[1][i] != undefined) {
       if (strings[0][i] !== strings[1][i]) {
         updatedStrings.push([i, strings[0][i], strings[1][i]]);
       }
@@ -111,7 +111,7 @@ function diff(strings) {
     }
   }
   for (const i of Object.keys(strings[1])) {
-    if (!strings[0][i]) {
+    if (strings[0][i] == undefined) {
       addedStrings.push([i, strings[1][i]]);
     }
   }

--- a/getLangStrings.js
+++ b/getLangStrings.js
@@ -7,6 +7,9 @@ export default function getLangStrings(file) {
 	const ast = acorn.parse(file, {ecmaVersion: "2022"});
 	walk.simple(ast, {
 		ObjectExpression(node) {
+			// There are two objects with strings.
+			// One of them has DISCORD_NAME,
+			// the other one has DISCORD_DESC_SHORT.
 			if(node.properties.find(x => x.key?.type === "Identifier" && (x.key.name === "DISCORD_NAME" || x.key.name === "DISCORD_DESC_SHORT"))) {
 				for(const property of node.properties) {
 					allStrings[property.key.name] = property.value.raw;

--- a/getLangStrings.js
+++ b/getLangStrings.js
@@ -1,87 +1,19 @@
-// HOLY SHIT I HATE THIS
+import * as acorn from "acorn";
+import * as walk from "acorn-walk"
 
-import { parse } from "espree";
-export default getLangStrings;
+export default function getLangStrings(file) {
+	const allStrings = {};
 
-// I really really hate this, but this is much safer than regex+eval
-function getLangStrings(file) {
-  const tree = parse(file, {
-    ecmaVersion: 2022,
-  });
+	const ast = acorn.parse(file, {ecmaVersion: "2022"});
+	walk.simple(ast, {
+		ObjectExpression(node) {
+			if(node.properties.find(x => x.key?.type === "Identifier" && (x.key.name === "DISCORD_NAME" || x.key.name === "DISCORD_DESC_SHORT"))) {
+				for(const property of node.properties) {
+					allStrings[property.key.name] = property.value.raw;
+				}
+			}
+		}
+	})
 
-  const webpackModules =
-    tree.body[0].expression.arguments[0].elements[1].properties;
-
-  const allStrings = {};
-
-  function parseStrings(webpackModule) {
-    const expression = webpackModule?.value?.body?.body?.[2]?.expression;
-    if (!expression) {
-      return;
-    }
-
-    if (
-      expression.right?.callee?.object?.name === "Object" &&
-      expression.right?.callee?.property?.name === "freeze" &&
-      expression.right?.arguments?.[0].expressions?.[0]?.arguments?.[0]
-    ) {
-      // parse frozen object
-      const properties =
-        expression.right.arguments[0].expressions[0].arguments[0].right
-          .properties;
-      if (
-        properties.some((suspectedLangModule) => {
-          if (
-            suspectedLangModule.key.name === "DISCORD_DESC_SHORT" ||
-            suspectedLangModule.key.name === "DISCORD_NAME"
-          ) {
-            return true;
-          }
-        })
-      ) {
-        properties.forEach((langEntry) => {
-          allStrings[langEntry.key.name] = langEntry.value.raw;
-        });
-      }
-
-      // parse function call arguments
-      expression.right.arguments[0].expressions.forEach((callExpr) => {
-        if (callExpr.arguments?.[1] && callExpr.arguments?.[2])
-          allStrings[callExpr.arguments[1].value] = callExpr.arguments[2].raw;
-      });
-    }
-  }
-
-  function parseUntranslatedStrings(webpackModule) {
-    const expression = webpackModule?.value?.body?.body?.[0]?.expression;
-    if (!expression) {
-      return;
-    }
-
-    if (
-      expression.right?.callee?.object?.name === "Object" &&
-      expression.right?.callee?.property?.name === "freeze" &&
-      expression.right?.arguments[0]?.properties
-    ) {
-      const properties = expression.right.arguments[0].properties;
-      if (
-        properties.every(
-          (suspectedLangModule) =>
-            suspectedLangModule.key.type === "Identifier" &&
-            suspectedLangModule.value.type === "Literal"
-        )
-      ) {
-        properties.forEach((langEntry) => {
-          allStrings[langEntry.key.name] = langEntry.value.raw;
-        });
-      }
-    }
-  }
-
-  webpackModules.forEach((webpackModule) => {
-    parseStrings(webpackModule);
-    parseUntranslatedStrings(webpackModule);
-  });
-
-  return allStrings;
+	return allStrings;
 }

--- a/getLangStrings.js
+++ b/getLangStrings.js
@@ -12,7 +12,9 @@ export default function getLangStrings(file) {
 			// the other one has DISCORD_DESC_SHORT.
 			if(node.properties.find(x => x.key?.type === "Identifier" && (x.key.name === "DISCORD_NAME" || x.key.name === "DISCORD_DESC_SHORT"))) {
 				for(const property of node.properties) {
-					allStrings[property.key.name] = property.value.raw;
+					// String literals as keys, ex. {"a": "b"} will have `value`
+					// Normal keys, ex. {a: "b"} will have `name`
+					allStrings[property.key.value ?? property.key.name] = property.value.raw;
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "dependencies": {
+    "acorn": "^8.11.2",
+    "acorn-walk": "^8.3.1",
     "espree": "^9.3.2"
   }
 }


### PR DESCRIPTION
This implements a proper AST walker instead of hardcoding expression indexes, which fixes the bug where only one of two language modules would be parsed.

This also fixes a bug with empty string handling.