### PR TITLE
fix(strings): handle template literals

### DIFF
--- a/getLangStrings.js
+++ b/getLangStrings.js
@@ -14,7 +14,19 @@ export default function getLangStrings(file) {
 				for(const property of node.properties) {
 					// String literals as keys, ex. {"a": "b"} will have `value`
 					// Normal keys, ex. {a: "b"} will have `name`
-					allStrings[property.key.value ?? property.key.name] = property.value.raw;
+					const stringKey = property.key.value ?? property.key.name
+
+					let stringVal
+					if(property.value.type === "Literal") {
+						stringVal = property.value.raw
+					} else if(property.value.type === "TemplateLiteral") {
+						const fullString = property.value.quasis.map(x => x.value.cooked).join("") // This assumes there will be no ${} expressions
+						const rawString = JSON.stringify(fullString)
+
+						stringVal = rawString
+					}
+
+					allStrings[stringKey] = stringVal
 				}
 			}
 		}


### PR DESCRIPTION
This adds support for handling template literals to the AST walker, which have been introduced to Discord's language files in today's update.

Note: acorn doesn't provide a regular quote string equivalent of the "raw" value of TemplateLiterals, so there are two possible ways to handle this:

1. Return the string as-is in backticks format, ex.
~~~diff
# Added
+ EMAIL_VERIFICATION_INSTRUCTIONS_BODY: `
+ We sent instructions to change your password to **!!{email}!!**, please check both your inbox and spam folder.
+ `
~~~
2. Manually convert it to the usual format
~~~diff
# Added
+ EMAIL_VERIFICATION_INSTRUCTIONS_BODY: "\nWe sent instructions to change your password to **!!{email}!!**, please check both your inbox and spam folder.\n"
~~~

I went with the 2nd way by using `JSON.stringify()` because imo it looks better, and also to prevent noise when Discord changes a string from "" quotes to `` backticks or vice versa.