### PR TITLE
fix(strings): handle call expressions

### DIFF
--- a/getLangStrings.js
+++ b/getLangStrings.js
@@ -1,36 +1,53 @@
 import * as acorn from "acorn";
 import * as walk from "acorn-walk"
 
+function copyASTObject(node, target) {
+	for(const property of node.properties) {
+		// String literals as keys, ex. {"a": "b"} will have `value`
+		// Normal keys, ex. {a: "b"} will have `name`
+		const stringKey = property.key.value ?? property.key.name
+
+		let stringVal
+		if(property.value.type === "Literal") {
+			stringVal = property.value.raw
+		} else if(property.value.type === "TemplateLiteral") {
+			const fullString = property.value.quasis.map(x => x.value.cooked).join("") // This assumes there will be no ${} expressions
+			const rawString = JSON.stringify(fullString)
+
+			stringVal = rawString
+		}
+		target[stringKey] = stringVal
+	}
+}
+
+
 export default function getLangStrings(file) {
 	const allStrings = {};
 
 	const ast = acorn.parse(file, {ecmaVersion: "2022"});
 	walk.simple(ast, {
-		ObjectExpression(node) {
+		ObjectExpression(node, state) {
 			// There are two objects with strings.
 			// One of them has DISCORD_NAME,
 			// the other one has DISCORD_DESC_SHORT.
-			if(node.properties.find(x => x.key?.type === "Identifier" && (x.key.name === "DISCORD_NAME" || x.key.name === "DISCORD_DESC_SHORT"))) {
-				for(const property of node.properties) {
-					// String literals as keys, ex. {"a": "b"} will have `value`
-					// Normal keys, ex. {a: "b"} will have `name`
-					const stringKey = property.key.value ?? property.key.name
+			if(state.step === 0 && node.properties.find(x => x.key?.type === "Identifier" && x.key.name === "DISCORD_DESC_SHORT")) {
+				copyASTObject(node, allStrings)
+				state.step = 1
+			} else if(state.step === 1 && node.properties.find(x => x.key?.type === "Identifier" && x.key.name === "DISCORD_NAME")) {
+				copyASTObject(node, allStrings)
+				state.step = 2
+			}
+		},
+		CallExpression(node, state) {
+			// Handles the `n(t, "KEY", "val")` calls
+			if(state.step === 1 && node.arguments.length === 3) {
+				const stringKey = node.arguments[1].value
+				const stringVal = node.arguments[2].value
 
-					let stringVal
-					if(property.value.type === "Literal") {
-						stringVal = property.value.raw
-					} else if(property.value.type === "TemplateLiteral") {
-						const fullString = property.value.quasis.map(x => x.value.cooked).join("") // This assumes there will be no ${} expressions
-						const rawString = JSON.stringify(fullString)
-
-						stringVal = rawString
-					}
-
-					allStrings[stringKey] = stringVal
-				}
+				allStrings[stringKey] = JSON.stringify(stringVal)
 			}
 		}
-	})
+	}, undefined, {step: 0})
 
 	return allStrings;
 }

--- a/getLangStrings.js
+++ b/getLangStrings.js
@@ -42,9 +42,9 @@ export default function getLangStrings(file) {
 			// Handles the `n(t, "KEY", "val")` calls
 			if(state.step === 1 && node.arguments.length === 3) {
 				const stringKey = node.arguments[1].value
-				const stringVal = node.arguments[2].value
+				const stringVal = node.arguments[2].raw
 
-				allStrings[stringKey] = JSON.stringify(stringVal)
+				allStrings[stringKey] = stringVal
 			}
 		}
 	}, undefined, {step: 0})


### PR DESCRIPTION
This adds support for handling the `n(t, "KEY", "value")` expressions to the AST walker, which have been introduced to Discord's language files in today's update.

(I'm going crazy)